### PR TITLE
Add token link to audio detail

### DIFF
--- a/app/src/Audio.js
+++ b/app/src/Audio.js
@@ -116,8 +116,14 @@ export default function AudioDetail(props) {
                             }
                         </div>
                         <div className="mt-5">
-                            Owner: <a href={process.env.REACT_APP_ETH_SCAN + "/address/" + owner} target="_blank">{owner}</a>
+                            <div>
+                                Owner: <a href={process.env.REACT_APP_ETH_SCAN + "/address/" + owner} target="_blank">{owner}</a>
+                            </div>
+                            <div>
+                                Token: <a href={process.env.REACT_APP_ETH_SCAN + "/token/" + props.contract.options.address + "?" + audioId } target="_blank">{audioId}</a>
+                            </div>
                         </div>
+                        
                     </div>
                     <div className="col">
                         <h1 className="h1">{resource.title}</h1>


### PR DESCRIPTION
Hey, interesting project! I added a token URL that takes you to the token on etherscan, similar to being able to view the owner as can be seen in the screenshot below:
![image](https://user-images.githubusercontent.com/5469870/116611478-b2eaea00-a936-11eb-8f09-00e1cbaf0e1c.png)

